### PR TITLE
v1.0.0-beta5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,12 @@ jobs:
       - name: Setup Environment Variables For Build Process
         id: current_version
         run: |
-          # Read Version from gradle.properties
-          echo "VERSION=`grep '^version=' gradle.properties | cut -d'=' -f2`" >> $GITHUB_ENV
+          TMPVERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+          if [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
+            # Replace existing prerelease identifier with -snapshot or append -snapshot if none exists
+            TMPVERSION=$(echo $TMPVERSION | sed 's/-.*$//')-snapshot
+          fi
+          echo "VERSION=$TMPVERSION" >> $GITHUB_ENV
 
           # Branch
           echo "Github Ref is $GITHUB_REF"

--- a/box.json
+++ b/box.json
@@ -2,7 +2,7 @@
     "name": "BoxLang Servlet Runtime",
     "shortDescription": "The BoxLang Servlet Runtime",
     "slug": "boxlang-servlet",
-    "version": "@build.version@+@build.number@",
+    "version": "@build.version@",
     "location": "https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/boxlang-servlet/@build.version@/boxlang-servlet-@build.version@.zip",
     "author": "Ortus Solutions",
     "homepage": "https://github.com/ortus-boxlang/boxlang-servlet",
@@ -17,7 +17,7 @@
         "boxlang"
     ],
     "private": false,
-	"listed": false,
+    "listed": false,
     "license": [
         {
             "type": "Apache-2.0",

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,13 @@ ext {
 	branch = System.getenv( 'BRANCH' ) ?: 'development'
 }
 
+if (branch == 'development') {
+    // If the branch is 'development', ensure the version ends with '-snapshot'
+    // This replaces any existing prerelease identifier with '-snapshot'
+    version = version.contains('-') ? version.replaceAll(/-.*/, '-snapshot') : "${version}-snapshot"
+	boxlangVersion = boxlangVersion.contains('-') ? boxlangVersion.replaceAll(/-.*/, '-snapshot') : "${boxlangVersion}-snapshot"
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -76,12 +83,8 @@ compileTestJava {
 jar {
     archiveVersion =  "${version}"
  	manifest {
-	   	attributes 'Description': 'The BoxLang Servlet Runtime'
-		 if( branch == 'development' ){
-		   attributes 'Implementation-Version': "${version}-SNAPSHOT"
-	   } else {
-		   attributes 'Implementation-Version': "${version}+${buildID}"
-	   }
+	   attributes 'Description': 'The BoxLang Servlet Runtime'
+	   attributes 'Implementation-Version': "${version}+${buildID}"
 	   attributes 'Created-On': new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( new Date() )
 	   attributes 'Created-By': "Ortus Solutions, Corp"
     }
@@ -119,13 +122,7 @@ processResources {
 	// Replace @build.date@ with the current date in META-INF/version.properties file
 	filter( ReplaceTokens, tokens: [ 'build.date': new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( new Date() ) ] )
 	// Replace @build.version@ with the current version in META-INF/version.properties file
-	filter( ReplaceTokens, tokens: [ 'build.version': version ] )
-	// If we are in branch == development then update +build.number to -SNAPSHOT
-	if( branch == 'development' ){
-		filter( ReplaceTokens, tokens: [ 'build.number': "-SNAPSHOT" ] )
-	} else {
-		filter( ReplaceTokens, tokens: [ 'build.number': "+" + buildID ] )
-	}
+	filter( ReplaceTokens, tokens: [ 'build.version': version + "+" + buildID ] )
 }
 
 javadoc {
@@ -186,11 +183,10 @@ task createWar( type: Copy ){
 		include "web.xml"
 		include "box.json"
 		// Token Replacements Go Here
-		filter{ line -> line.replaceAll( '@build.version@', project.version ) }
 		if( project.branch == "development" ){
-			filter{ line -> line.replaceAll( '\\+@build.number@', '-SNAPSHOT' ) }
+			filter{ line -> line.replaceAll( '@build.version@', project.version ) }
 		} else {
-			filter{ line -> line.replaceAll( '@build.number@', project.buildID ) }
+			filter{ line -> line.replaceAll( '@build.version@', project.version + "+" + project.buildID ) }
 		}
 		into "engine/WEB-INF"
 	}

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta4] - 2024-07-05
+
 ## [1.0.0-beta3] - 2024-06-28
 
 ## [1.0.0-beta2] - 2024-06-21
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta3...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta4...HEAD
 
 [1.0.0-beta4]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta4...v1.0.0-beta4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Jun 28 10:56:24 UTC 2024
-boxlangVersion=1.0.0-beta4
+#Fri Jul 05 15:15:32 UTC 2024
+boxlangVersion=1.0.0-beta5
 jdkVersion=21
-version=1.0.0-beta4
+version=1.0.0-beta5
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
@@ -47,7 +47,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUpload;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
@@ -97,6 +96,33 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 		this.servletContext	= request.getServletContext();
 		this.request		= request;
 		this.response		= response;
+	}
+
+	/**
+	 * Get the servlet context
+	 * 
+	 * @return The servlet context
+	 */
+	public ServletContext getServletContext() {
+		return servletContext;
+	}
+
+	/**
+	 * Get the servlet request
+	 * 
+	 * @return The servlet request
+	 */
+	public HttpServletRequest getServletRequest() {
+		return request;
+	}
+
+	/**
+	 * Get the servlet response
+	 * 
+	 * @return The servlet response
+	 */
+	public HttpServletResponse getServletResponse() {
+		return response;
 	}
 
 	@Override

--- a/src/main/resources/META-INF/boxlang-servlet/version.properties
+++ b/src/main/resources/META-INF/boxlang-servlet/version.properties
@@ -1,2 +1,2 @@
-version=@build.version@@build.number@
+version=@build.version@
 buildDate=@build.date@

--- a/src/main/resources/boxlang-servlet/box.json
+++ b/src/main/resources/boxlang-servlet/box.json
@@ -1,7 +1,7 @@
 {
 	"name": "BoxLang CommandBox Engine",
 	"slug": "boxlang",
-	"version": "@build.version@+@build.number@",
+	"version": "@build.version@",
 	"type": "cf-engines",
 	"description": "The CommandBox Engine for BoxLang",
 	"createPackageDirectory": false,


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-beta5

### New Feature

[BL-319](https://ortussolutions.atlassian.net/browse/BL-319) Ability to call on \`navigate\( String... paths\)\` on the \`Configuration\` to create data navigators

[BL-320](https://ortussolutions.atlassian.net/browse/BL-320) Store the original last configuration seeded into the runtime as \`originalConfig\`

[BL-322](https://ortussolutions.atlassian.net/browse/BL-322) New StringBind\(\) bif and member function to bind a string with placeholder replacements using the \`$\{key\}\`

[BL-324](https://ortussolutions.atlassian.net/browse/BL-324) attempts now have a isNull\(\) to explicitly determine if the value is null

[BL-325](https://ortussolutions.atlassian.net/browse/BL-325) Allow Java methods to be referenced and passed around as a variable and invoked later like UDFs allow

[BL-326](https://ortussolutions.atlassian.net/browse/BL-326) New Application global defaults in the boxlang.json

[BL-330](https://ortussolutions.atlassian.net/browse/BL-330) new interception points when a session get's created and destroyed

[BL-338](https://ortussolutions.atlassian.net/browse/BL-338) Allow Java functional interfaces and SAMs to be wrapped and used as functions

[BL-339](https://ortussolutions.atlassian.net/browse/BL-339) All locations in the cache that returned optionals, now returns BoxLang Attempts

[BL-340](https://ortussolutions.atlassian.net/browse/BL-340) getAsAttempt\(\) on the IStruct default methods for convenience

[BL-341](https://ortussolutions.atlassian.net/browse/BL-341) BoxCacheProviders now have a localized interceptor pool alongside the runtime pool

[BL-342](https://ortussolutions.atlassian.net/browse/BL-342) Sessions are now monitored by cache interceptors to detect removals so as to shutdown the sessions before removal

[BL-343](https://ortussolutions.atlassian.net/browse/BL-343) application, session, request timeouts in the boxlang.json are now string timespans

[BL-344](https://ortussolutions.atlassian.net/browse/BL-344) App Timeouts are now working

### Improvement

[BL-209](https://ortussolutions.atlassian.net/browse/BL-209) Combine config settings into a single struct

[BL-318](https://ortussolutions.atlassian.net/browse/BL-318) Allow optional attribute delimiters in ACF tag-in-script syntax

[BL-321](https://ortussolutions.atlassian.net/browse/BL-321) Refactor dump loading of CSS to use caching again

[BL-323](https://ortussolutions.atlassian.net/browse/BL-323) Refactor page pool to be per-mapping

[BL-329](https://ortussolutions.atlassian.net/browse/BL-329) jsessionID is the internal standard for boxlang sessions, move to this instead of cfid

[BL-332](https://ortussolutions.atlassian.net/browse/BL-332) getOrSet\(\) in the cache should return the object not an optional

### Bug

[BL-164](https://ortussolutions.atlassian.net/browse/BL-164) BL Compat module should coerce null values to empty string

[BL-252](https://ortussolutions.atlassian.net/browse/BL-252) MSSQL DROP TABLE throws 'The statement must be executed before any results can be obtained'

[BL-306](https://ortussolutions.atlassian.net/browse/BL-306) Adobe Compatibility: Missing support for new java\(\) and new component\(\)

[BL-308](https://ortussolutions.atlassian.net/browse/BL-308) cfinvoke does not support params as attribute-value pairs

[BL-316](https://ortussolutions.atlassian.net/browse/BL-316) If the global runtime \`javaLibraryPaths\` is already a jar/class location, then use it, else it breaks

[BL-317](https://ortussolutions.atlassian.net/browse/BL-317) allow "var" before CF catch variable in script

[BL-331](https://ortussolutions.atlassian.net/browse/BL-331) ResetSession on the scripting request context was invalidating the new session instead of the old session

[BL-333](https://ortussolutions.atlassian.net/browse/BL-333) Session creation if the default timeout is not a duration, it should treat it as seconds, not milliseconds

[BL-334](https://ortussolutions.atlassian.net/browse/BL-334) Session object was not serializable

[BL-335](https://ortussolutions.atlassian.net/browse/BL-335) Cache was evicting items without reaping

[BL-336](https://ortussolutions.atlassian.net/browse/BL-336) DateTime toString\(\) not accounting for formatter being null

[BL-337](https://ortussolutions.atlassian.net/browse/BL-337) sessionRotate\(\) not copying over old keys due to nullification of keys when invalidating the old session

[BL-319]: https://ortussolutions.atlassian.net/browse/BL-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-320]: https://ortussolutions.atlassian.net/browse/BL-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-322]: https://ortussolutions.atlassian.net/browse/BL-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-324]: https://ortussolutions.atlassian.net/browse/BL-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-325]: https://ortussolutions.atlassian.net/browse/BL-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-326]: https://ortussolutions.atlassian.net/browse/BL-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-330]: https://ortussolutions.atlassian.net/browse/BL-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-338]: https://ortussolutions.atlassian.net/browse/BL-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ