### PR TITLE
v1.0.0-Beta7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta6] - 2024-07-19
+
 ## [1.0.0-beta5] - 2024-07-12
 
 ## [1.0.0-beta4] - 2024-07-05
@@ -21,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta5...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta6...HEAD
+
+[1.0.0-beta6]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta5...v1.0.0-beta6
 
 [1.0.0-beta5]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta4...v1.0.0-beta5
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Jul 12 11:12:45 UTC 2024
-boxlangVersion=1.0.0-beta6
+#Fri Jul 19 17:13:30 UTC 2024
+boxlangVersion=1.0.0-beta7
 jdkVersion=21
-version=1.0.0-beta6
+version=1.0.0-beta7
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
@@ -51,6 +51,7 @@ import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.io.output.NullWriter;
 
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
@@ -506,6 +507,9 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 			return response.getWriter();
 		} catch ( IOException e ) {
 			throw new BoxRuntimeException( "Could not get response writer", e );
+		} catch ( IllegalStateException e ) {
+			// reponse has already been sent, so return a dummy writer
+			return new PrintWriter( NullWriter.INSTANCE );
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
@@ -310,7 +310,7 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 				if ( !params.containsKey( key ) ) {
 					params.put( key, new LinkedList<String>() );
 				}
-				String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode( pair.substring( idx + 1 ), "UTF-8" ) : null;
+				String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode( pair.substring( idx + 1 ), "UTF-8" ) : "";
 				params.get( key ).add( value );
 			}
 


### PR DESCRIPTION
BoxLang Betas are released weekly.  This is our fifth beta marker.  Here are the release notes.
Improvements
[BL-376](https://ortussolutions.atlassian.net/browse/BL-376) web support error template only shows details of exceptions if IN debug mode else secure by default
[BL-392](https://ortussolutions.atlassian.net/browse/BL-392) Consolidate the runtime into services without the need of getInstance()
New Features
[BL-374](https://ortussolutions.atlassian.net/browse/BL-374) threadNew() bif to complete the thread bifs that was always missing
[BL-388](https://ortussolutions.atlassian.net/browse/BL-388) Stream type and collector member methods
[BL-390](https://ortussolutions.atlassian.net/browse/BL-390) orThrow( type, message ) for attempts
[BL-391](https://ortussolutions.atlassian.net/browse/BL-391) ifSuccessful() alias to ifPresent() on attempts
Bugs
[BL-373](https://ortussolutions.atlassian.net/browse/BL-373) Parser detection for unparsed tokens only works if there are 2 or more tokens left
[BL-377](https://ortussolutions.atlassian.net/browse/BL-377) Declaring UDFs in function context doesn't always work
[BL-378](https://ortussolutions.atlassian.net/browse/BL-378) CFConfig datasources aren't importing due to lack of support for the 'dbdriver' key
[BL-379](https://ortussolutions.atlassian.net/browse/BL-379) Runtime can deadlock due to syncronized methods
[BL-380](https://ortussolutions.atlassian.net/browse/BL-380) NPE calling isNumeric()
[BL-381](https://ortussolutions.atlassian.net/browse/BL-381) JSONSerialize() errors when useSecureJSONPrefix not a boolean
[BL-385](https://ortussolutions.atlassian.net/browse/BL-385) Cannot call getWriter(), getOutputStream() already called
[BL-386](https://ortussolutions.atlassian.net/browse/BL-386) empty url vars coming through as null
Tasks
[BL-372](https://ortussolutions.atlassian.net/browse/BL-372) Create tests for al valid and invalid dot and array access expressions

[BL-376]: https://ortussolutions.atlassian.net/browse/BL-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-392]: https://ortussolutions.atlassian.net/browse/BL-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-374]: https://ortussolutions.atlassian.net/browse/BL-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-388]: https://ortussolutions.atlassian.net/browse/BL-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-390]: https://ortussolutions.atlassian.net/browse/BL-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-391]: https://ortussolutions.atlassian.net/browse/BL-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-373]: https://ortussolutions.atlassian.net/browse/BL-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-377]: https://ortussolutions.atlassian.net/browse/BL-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ