### PR TITLE
v1.0.0-Beta17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     permissions:
       checks: write
       contents: write
+      packages: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -160,17 +161,17 @@ jobs:
           DEST_DIR: "boxlang-runtimes/${{ env.MODULE_ID }}/${{ env.VERSION }}"
 
       # Publish to Maven Central + Github ONLY on Beta/Final Releases
-      # - name: Publish Package (Maven+Github)
-      #   if: env.SNAPSHOT == 'false'
-      #   run: |
-      #     gradle publish --no-daemon --no-parallel
-      #     gradle publishAllPublicationsToCentralPortal
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     GPG_KEY: ${{ secrets.GPG_KEY }}
-      #     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-      #     MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-      #     MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      - name: Publish Package (Maven+Github)
+        if: env.SNAPSHOT == 'false'
+        run: |
+          gradle publish --no-daemon --no-parallel
+          gradle publishAllPublicationsToCentralPortal
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 
       - name: Publish to ForgeBox
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       #   if: env.SNAPSHOT == 'false'
       #   run: |
       #     gradle publish --no-daemon --no-parallel
-      #     gradle publishToSonatype closeAndReleaseSonatypeStagingRepository
+      #     gradle publishAllPublicationsToCentralPortal
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #     GPG_KEY: ${{ secrets.GPG_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,9 @@ publishing {
 					}
 				}
 				scm {
-					connection = 'scm:git:https://github.com/ortus-boxlang/boxlang.git'
-					developerConnection = 'scm:git:ssh://github.com/ortus-boxlang/boxlang.git'
-					url = 'https://github.com/ortus-boxlang/boxlang'
+					connection = 'scm:git:https://github.com/ortus-boxlang/boxlang-servlet.git'
+					developerConnection = 'scm:git:ssh://github.com/ortus-boxlang/boxlang-servlet.git'
+					url = 'https://github.com/ortus-boxlang/boxlang-servlet'
 				}
 				developers{
 					developer {
@@ -214,7 +214,7 @@ publishing {
         }
 		maven {
 			name = "GitHubPackages"
-			url = "https://maven.pkg.github.com/ortus-boxlang/boxlang"
+			url = "https://maven.pkg.github.com/ortus-boxlang/boxlang-servlet"
 			credentials {
 				username = System.getenv( "GITHUB_ACTOR" )
 				password = System.getenv( "GITHUB_TOKEN" )

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta16] - 2024-09-27
+
 ## [1.0.0-beta15] - 2024-09-20
 
 ## [1.0.0-beta14] - 2024-09-13
@@ -41,7 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta15...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta16...HEAD
+
+[1.0.0-beta16]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta15...v1.0.0-beta16
 
 [1.0.0-beta15]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta14...v1.0.0-beta15
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Sep 20 13:05:51 UTC 2024
-boxlangVersion=1.0.0-beta16
+#Fri Sep 27 20:20:29 UTC 2024
+boxlangVersion=1.0.0-beta17
 jdkVersion=21
-version=1.0.0-beta16
+version=1.0.0-beta17
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
@@ -70,10 +70,13 @@ public class BoxLangServlet implements Servlet {
 			BLHome = Path.of( customHome );
 		}
 		// Null, if not exists
-		Boolean	debug		= Boolean.parseBoolean( config.getInitParameter( "boxlang-debug" ) );
+		Boolean	debug		= null;
+		String	debugParam	= config.getInitParameter( "boxlang-debug" );
+
 		// Null, if not exists. Must be absolute path.
 		String	configPath	= config.getInitParameter( "boxlang-config-path" );
-		if ( debug != null ) {
+		if ( debugParam != null ) {
+			debug = Boolean.parseBoolean( debugParam );
 			System.out.println( "Ortus BoxLang Servlet debug mode: " + debug );
 		}
 		if ( configPath != null ) {


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta17

### Bug

[BL-608](https://ortussolutions.atlassian.net/browse/BL-608) Timeouts \(connection, idle\) for datasources needs to be in seconds and not in milliseconds to adhere to cfconfig

[BL-609](https://ortussolutions.atlassian.net/browse/BL-609) BoxLang resolvers do not allow class paths to have \`-\` in them.

### Improvement

[BL-607](https://ortussolutions.atlassian.net/browse/BL-607) Add version/build date to output of Miniserver startup

[BL-610](https://ortussolutions.atlassian.net/browse/BL-610) onSessionEnd needs application settings made available

[BL-611](https://ortussolutions.atlassian.net/browse/BL-611) Remove debugmode capture on miniserver, delegate to the core runtime.

### New Feature

[BL-605](https://ortussolutions.atlassian.net/browse/BL-605) MiniServer WebSocket handler

[BL-608]: https://ortussolutions.atlassian.net/browse/BL-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-609]: https://ortussolutions.atlassian.net/browse/BL-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-607]: https://ortussolutions.atlassian.net/browse/BL-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-610]: https://ortussolutions.atlassian.net/browse/BL-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-611]: https://ortussolutions.atlassian.net/browse/BL-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-605]: https://ortussolutions.atlassian.net/browse/BL-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ