### PR TITLE
1.0.0-Beta18

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta17] - 2024-10-04
+
 ## [1.0.0-beta16] - 2024-09-27
 
 ## [1.0.0-beta15] - 2024-09-20
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta16...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta17...HEAD
+
+[1.0.0-beta17]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta16...v1.0.0-beta17
 
 [1.0.0-beta16]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta15...v1.0.0-beta16
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Sep 27 20:20:29 UTC 2024
-boxlangVersion=1.0.0-beta17
+#Fri Oct 04 19:25:39 UTC 2024
+boxlangVersion=1.0.0-beta18
 jdkVersion=21
-version=1.0.0-beta17
+version=1.0.0-beta18
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.web.WebRequestExecutor;
 import ortus.boxlang.web.exchange.BoxHTTPServletExchange;
 
@@ -89,6 +90,10 @@ public class BoxLangServlet implements Servlet {
 		this.runtime.getInterceptorService().register( new ServletMappingInterceptor( config.getServletContext() ) );
 
 		System.out.println( "Ortus BoxLang Servlet initialized!" );
+		IStruct versionInfo = runtime.getVersionInfo();
+		System.out.println(
+		    "Ortus BoxLang Version: " + versionInfo.getAsString( Key.of( "version" ) ) + " (Built On: " + versionInfo.getAsString( Key.of( "buildDate" ) )
+		        + ")" );
 	}
 
 	/**


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta18

### New Feature

[BL-617](https://ortussolutions.atlassian.net/browse/BL-617) arrayFind, arrayFindNoCase value closures, accept the value and now the index of the item as the second param

[BL-626](https://ortussolutions.atlassian.net/browse/BL-626) New configuration: validBoxLangTemplates to determine which templates the Runnable Loader can process

[BL-627](https://ortussolutions.atlassian.net/browse/BL-627) New configuration: validClassExtensions to determine which class extensions to work with

[BL-629](https://ortussolutions.atlassian.net/browse/BL-629) New security configuration section for disallowing: BIFS, Components, Imports

[BL-630](https://ortussolutions.atlassian.net/browse/BL-630) Internal refactor to make the class locator and resolvers have a life-cycle based on the runtime and not alone

### Bug

[BL-614](https://ortussolutions.atlassian.net/browse/BL-614) Import nested classes

[BL-615](https://ortussolutions.atlassian.net/browse/BL-615) Java static funcitons not behaving as expected

[BL-616](https://ortussolutions.atlassian.net/browse/BL-616) array.find does not use cf rules to convert result of predicate to boolean

[BL-619](https://ortussolutions.atlassian.net/browse/BL-619) QueryColumnType doesn't handle "idstamp" \(mssql\)

[BL-620](https://ortussolutions.atlassian.net/browse/BL-620) static scope in application.cfc not initialized before psuedoConstructor runs

[BL-624](https://ortussolutions.atlassian.net/browse/BL-624) Auto-escaping of \{\} in regex needs to ignore already-escaped braces

[BL-625](https://ortussolutions.atlassian.net/browse/BL-625) Instead of removing special chars from Java FQN, replace with \_\_ to avoid conflicts

[BL-628](https://ortussolutions.atlassian.net/browse/BL-628) Tag expressions not parsing inside template island inside braces

[BL-631](https://ortussolutions.atlassian.net/browse/BL-631) duplicate\(\) doesn't work on empty structs

[BL-633](https://ortussolutions.atlassian.net/browse/BL-633) randrange\(\) not inclusive of upper bound

[BL-634](https://ortussolutions.atlassian.net/browse/BL-634) array.find - can't cast closure to string

### Improvement

[BL-611](https://ortussolutions.atlassian.net/browse/BL-611) Remove debugmode capture on miniserver, delegate to the core runtime.

[BL-622](https://ortussolutions.atlassian.net/browse/BL-622) Consolidate CastAttempt and Attempt into a hierarchy

[BL-623](https://ortussolutions.atlassian.net/browse/BL-623) New DynamicFunction type that can be used to generate dynamic BoxLang functions using Java Lambda proxies. Great for code generation

[BL-617]: https://ortussolutions.atlassian.net/browse/BL-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-626]: https://ortussolutions.atlassian.net/browse/BL-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-627]: https://ortussolutions.atlassian.net/browse/BL-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-629]: https://ortussolutions.atlassian.net/browse/BL-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-630]: https://ortussolutions.atlassian.net/browse/BL-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-614]: https://ortussolutions.atlassian.net/browse/BL-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-615]: https://ortussolutions.atlassian.net/browse/BL-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-616]: https://ortussolutions.atlassian.net/browse/BL-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ