### PR TITLE
1.0.0-Beta19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	// Servlet API
 	implementation 'javax.servlet:javax.servlet-api:4.0.1'
+	// We only need this for the PageContext class
+	implementation 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.3'
+
 
  	implementation 'commons-fileupload:commons-fileupload:1.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,10 @@ dependencies {
 
 	// Servlet API
 	implementation 'javax.servlet:javax.servlet-api:4.0.1'
-	// We only need this for the PageContext class
+	// We only need these for the PageContext class
 	implementation 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.3'
+	implementation 'javax.el:javax.el-api:3.0.0'
+
 
 
  	implementation 'commons-fileupload:commons-fileupload:1.5'

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta18] - 2024-10-11
+
 ## [1.0.0-beta17] - 2024-10-04
 
 ## [1.0.0-beta16] - 2024-09-27
@@ -45,7 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta17...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta18...HEAD
+
+[1.0.0-beta18]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta17...v1.0.0-beta18
 
 [1.0.0-beta17]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta16...v1.0.0-beta17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Oct 04 19:25:39 UTC 2024
-boxlangVersion=1.0.0-beta18
+#Fri Oct 11 15:36:38 UTC 2024
+boxlangVersion=1.0.0-beta19
 jdkVersion=21
-version=1.0.0-beta18
+version=1.0.0-beta19
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
@@ -94,6 +94,7 @@ public class BoxLangServlet implements Servlet {
 		System.out.println(
 		    "Ortus BoxLang Version: " + versionInfo.getAsString( Key.of( "version" ) ) + " (Built On: " + versionInfo.getAsString( Key.of( "buildDate" ) )
 		        + ")" );
+
 	}
 
 	/**
@@ -108,7 +109,7 @@ public class BoxLangServlet implements Servlet {
 	public void service( ServletRequest req, ServletResponse res ) throws ServletException, IOException {
 		// FusionReactor automatically tracks servlets
 		// Note: web root can be different every request if this is a multi-site server or using ModCFML
-		var exchange = new BoxHTTPServletExchange( ( HttpServletRequest ) req, ( HttpServletResponse ) res );
+		var exchange = new BoxHTTPServletExchange( ( HttpServletRequest ) req, ( HttpServletResponse ) res, this );
 		try {
 			WebRequestExecutor.execute( exchange, config.getServletContext().getRealPath( "/" ), false );
 		} finally {

--- a/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
@@ -1,0 +1,257 @@
+package ortus.boxlang.servlet;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.el.ELContext;
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.el.ExpressionEvaluator;
+import javax.servlet.jsp.el.VariableResolver;
+
+public class BoxPageContext extends PageContext {
+
+	private final Map<String, Object>	pageAttributes	= new HashMap<>();
+	private ServletRequest				request;
+	private ServletResponse				response;
+	private HttpSession					session;
+	private ServletContext				application;
+	private Object						page;
+	private JspWriter					out;
+	private Exception					exception;
+	private ServletConfig				servletConfig;
+
+	@Override
+	public ELContext getELContext() {
+		throw new UnsupportedOperationException( "Not supported yet." );
+	}
+
+	@Override
+	public JspWriter getOut() {
+		return out;
+	}
+
+	@Override
+	public HttpSession getSession() {
+		return session;
+	}
+
+	@Override
+	public Object getAttribute( String name, int scope ) {
+		switch ( scope ) {
+			case PAGE_SCOPE :
+				return pageAttributes.get( name );
+			case REQUEST_SCOPE :
+				return request.getAttribute( name );
+			case SESSION_SCOPE :
+				return session.getAttribute( name );
+			case APPLICATION_SCOPE :
+				return application.getAttribute( name );
+			default :
+				throw new IllegalArgumentException( "Invalid scope: " + scope );
+		}
+	}
+
+	@Override
+	public Enumeration<String> getAttributeNamesInScope( int scope ) {
+		switch ( scope ) {
+			case PAGE_SCOPE :
+				return java.util.Collections.enumeration( pageAttributes.keySet() );
+			case REQUEST_SCOPE :
+				return request.getAttributeNames();
+			case SESSION_SCOPE :
+				return session.getAttributeNames();
+			case APPLICATION_SCOPE :
+				return application.getAttributeNames();
+			default :
+				throw new IllegalArgumentException( "Invalid scope: " + scope );
+		}
+	}
+
+	@Override
+	public int getAttributesScope( String name ) {
+		if ( pageAttributes.containsKey( name ) ) {
+			return PAGE_SCOPE;
+		} else if ( request.getAttribute( name ) != null ) {
+			return REQUEST_SCOPE;
+		} else if ( session != null && session.getAttribute( name ) != null ) {
+			return SESSION_SCOPE;
+		} else if ( application.getAttribute( name ) != null ) {
+			return APPLICATION_SCOPE;
+		} else {
+			return 0;
+		}
+	}
+
+	@Override
+	public void setAttribute( String name, Object value ) {
+		pageAttributes.put( name, value );
+	}
+
+	@Override
+	public void setAttribute( String name, Object value, int scope ) {
+		switch ( scope ) {
+			case PAGE_SCOPE :
+				pageAttributes.put( name, value );
+				break;
+			case REQUEST_SCOPE :
+				request.setAttribute( name, value );
+				break;
+			case SESSION_SCOPE :
+				session.setAttribute( name, value );
+				break;
+			case APPLICATION_SCOPE :
+				application.setAttribute( name, value );
+				break;
+			default :
+				throw new IllegalArgumentException( "Invalid scope: " + scope );
+		}
+	}
+
+	@Override
+	public Object getAttribute( String name ) {
+		return pageAttributes.get( name );
+	}
+
+	@Override
+	public Object findAttribute( String name ) {
+		Object value = pageAttributes.get( name );
+		if ( value == null ) {
+			value = request.getAttribute( name );
+		}
+		if ( value == null && session != null ) {
+			value = session.getAttribute( name );
+		}
+		if ( value == null ) {
+			value = application.getAttribute( name );
+		}
+		return value;
+	}
+
+	@Override
+	public void removeAttribute( String name ) {
+		pageAttributes.remove( name );
+	}
+
+	@Override
+	public void removeAttribute( String name, int scope ) {
+		switch ( scope ) {
+			case PAGE_SCOPE :
+				pageAttributes.remove( name );
+				break;
+			case REQUEST_SCOPE :
+				request.removeAttribute( name );
+				break;
+			case SESSION_SCOPE :
+				session.removeAttribute( name );
+				break;
+			case APPLICATION_SCOPE :
+				application.removeAttribute( name );
+				break;
+			default :
+				throw new IllegalArgumentException( "Invalid scope: " + scope );
+		}
+	}
+
+	@Override
+	public void initialize( Servlet servlet, ServletRequest request, ServletResponse response, String errorPageURL, boolean needsSession, int bufferSize,
+	    boolean autoFlush ) {
+		this.request		= request;
+		this.response		= response;
+		this.application	= request.getServletContext();
+		this.session		= needsSession ? ( ( HttpServletRequest ) request ).getSession() : null;
+	}
+
+	@Override
+	public void release() {
+		pageAttributes.clear();
+		request			= null;
+		response		= null;
+		session			= null;
+		application		= null;
+		page			= null;
+		out				= null;
+		exception		= null;
+		servletConfig	= null;
+	}
+
+	@Override
+	public Object getPage() {
+		return page;
+	}
+
+	@Override
+	public ServletRequest getRequest() {
+		return request;
+	}
+
+	@Override
+	public ServletResponse getResponse() {
+		return response;
+	}
+
+	@Override
+	public Exception getException() {
+		return exception;
+	}
+
+	@Override
+	public ServletConfig getServletConfig() {
+		return servletConfig;
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return application;
+	}
+
+	@Override
+	public void forward( String path ) throws ServletException, IOException {
+		request.getRequestDispatcher( path ).forward( request, response );
+	}
+
+	@Override
+	public void include( String path ) throws ServletException, IOException {
+		request.getRequestDispatcher( path ).include( request, response );
+	}
+
+	@Override
+	public void include( String path, boolean flush ) throws ServletException, IOException {
+		if ( flush ) {
+			// out.flush();
+		}
+		request.getRequestDispatcher( path ).include( request, response );
+	}
+
+	@SuppressWarnings( "deprecation" )
+	@Override
+	public ExpressionEvaluator getExpressionEvaluator() {
+		throw new UnsupportedOperationException( "Not supported yet." );
+	}
+
+	@SuppressWarnings( "deprecation" )
+	@Override
+	public VariableResolver getVariableResolver() {
+		throw new UnsupportedOperationException( "Not supported yet." );
+	}
+
+	@Override
+	public void handlePageException( Exception e ) throws ServletException, IOException {
+		throw new UnsupportedOperationException( "Not supported yet." );
+	}
+
+	@Override
+	public void handlePageException( Throwable t ) throws ServletException, IOException {
+		throw new UnsupportedOperationException( "Not supported yet." );
+	}
+}

--- a/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
@@ -12,7 +12,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
@@ -169,7 +168,7 @@ public class BoxPageContext extends PageContext {
 		this.request		= request;
 		this.response		= response;
 		this.application	= request.getServletContext();
-		this.session		= needsSession ? ( ( HttpServletRequest ) request ).getSession() : null;
+		this.session		= null;
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
@@ -1,0 +1,86 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import javax.servlet.jsp.JspFactory;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.BoxHTTPServletExchange;
+
+@BoxBIF
+public class GetPageContext extends BIF {
+
+	private static final Key page_context_attachment = Key.of( "page_context_attachment" );
+
+	/**
+	 * Constructor
+	 */
+	public GetPageContext() {
+		super();
+	}
+
+	/**
+	 *
+	 * Gets the current java PageContext object that provides access to page attributes and configuration, request and response objects.
+	 * If not running in a servlet, this will be a fake class attempting to provide most of the common methods.
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		WebRequestBoxContext requestContext = context.getParentOfType( WebRequestBoxContext.class );
+		// Create if neccessary
+		if ( !requestContext.hasAttachment( page_context_attachment ) ) {
+			synchronized ( requestContext ) {
+				// Double check lock pattern
+				if ( !requestContext.hasAttachment( page_context_attachment ) ) {
+					// Create a PageContext object
+					BoxHTTPServletExchange	exchange	= ( BoxHTTPServletExchange ) requestContext.getHTTPExchange();
+					JspFactory				jspFactory	= JspFactory.getDefaultFactory();
+
+					// Ensure the JspFactory is available (it should be in a servlet container)
+					if ( jspFactory != null ) {
+						// Create a PageContext for this request using the container's JSP engine
+						PageContext pageContext = jspFactory.getPageContext(
+						    exchange.getServlet(),
+						    exchange.getServletRequest(),
+						    exchange.getServletResponse(),
+						    null,
+						    true,
+						    JspWriter.DEFAULT_BUFFER,
+						    true
+						);
+						// Attach the PageContext to the request context so it's available for the duration of the request
+						requestContext.putAttachment( page_context_attachment, pageContext );
+					} else {
+						throw new BoxRuntimeException( "JspFactory is not available. This BIF can only be used in a servlet container." );
+					}
+				}
+			}
+		}
+		// Return the PageContext object which is now attached to the request context
+		return requestContext.getAttachment( page_context_attachment );
+	}
+
+}

--- a/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
@@ -14,16 +14,14 @@
  */
 package ortus.boxlang.web.bifs;
 
-import javax.servlet.jsp.JspFactory;
 import javax.servlet.jsp.JspWriter;
-import javax.servlet.jsp.PageContext;
 
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.servlet.BoxPageContext;
 import ortus.boxlang.web.context.WebRequestBoxContext;
 import ortus.boxlang.web.exchange.BoxHTTPServletExchange;
 
@@ -57,25 +55,19 @@ public class GetPageContext extends BIF {
 				if ( !requestContext.hasAttachment( page_context_attachment ) ) {
 					// Create a PageContext object
 					BoxHTTPServletExchange	exchange	= ( BoxHTTPServletExchange ) requestContext.getHTTPExchange();
-					JspFactory				jspFactory	= JspFactory.getDefaultFactory();
 
-					// Ensure the JspFactory is available (it should be in a servlet container)
-					if ( jspFactory != null ) {
-						// Create a PageContext for this request using the container's JSP engine
-						PageContext pageContext = jspFactory.getPageContext(
-						    exchange.getServlet(),
-						    exchange.getServletRequest(),
-						    exchange.getServletResponse(),
-						    null,
-						    true,
-						    JspWriter.DEFAULT_BUFFER,
-						    true
-						);
-						// Attach the PageContext to the request context so it's available for the duration of the request
-						requestContext.putAttachment( page_context_attachment, pageContext );
-					} else {
-						throw new BoxRuntimeException( "JspFactory is not available. This BIF can only be used in a servlet container." );
-					}
+					BoxPageContext			pageContext	= new BoxPageContext();
+					pageContext.initialize(
+					    exchange.getServlet(),
+					    exchange.getServletRequest(),
+					    exchange.getServletResponse(),
+					    null,
+					    true,
+					    JspWriter.DEFAULT_BUFFER,
+					    true
+					);
+					// Attach the PageContext to the request context so it's available for the duration of the request
+					requestContext.putAttachment( page_context_attachment, pageContext );
 				}
 			}
 		}

--- a/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxHTTPServletExchange.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
+import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -68,6 +69,11 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 	protected ServletContext		servletContext;
 
 	/**
+	 * The servlet
+	 */
+	protected Servlet				servlet;
+
+	/**
 	 * The servlet request
 	 */
 	protected HttpServletRequest	request;
@@ -93,10 +99,11 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 	 * @param request  The servlet request
 	 * @param response The servlet response
 	 */
-	public BoxHTTPServletExchange( HttpServletRequest request, HttpServletResponse response ) {
+	public BoxHTTPServletExchange( HttpServletRequest request, HttpServletResponse response, Servlet servlet ) {
 		this.servletContext	= request.getServletContext();
 		this.request		= request;
 		this.response		= response;
+		this.servlet		= servlet;
 	}
 
 	/**
@@ -124,6 +131,15 @@ public class BoxHTTPServletExchange implements IBoxHTTPExchange {
 	 */
 	public HttpServletResponse getServletResponse() {
 		return response;
+	}
+
+	/**
+	 * Get the servlet
+	 * 
+	 * @return The servlet
+	 */
+	public Servlet getServlet() {
+		return servlet;
 	}
 
 	@Override


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta19

### Bug

[BL-635](https://ortussolutions.atlassian.net/browse/BL-635) boxlang invokes private onApplicationStart

[BL-636](https://ortussolutions.atlassian.net/browse/BL-636) expandPath does not preserve file system case

[BL-639](https://ortussolutions.atlassian.net/browse/BL-639) cfml2wddx action missing

[BL-642](https://ortussolutions.atlassian.net/browse/BL-642) deserializeJSON not handling white space / control characters

[BL-645](https://ortussolutions.atlassian.net/browse/BL-645) Update parser to allow for \`@module\` notations on imports and \`new\` operators

[BL-649](https://ortussolutions.atlassian.net/browse/BL-649) listFind\(\) and listFindNoCase\(\) are allowing partial matches

[BL-651](https://ortussolutions.atlassian.net/browse/BL-651) Can't dump null in console

[BL-659](https://ortussolutions.atlassian.net/browse/BL-659)  Cannot invoke "java.lang.CharSequence.length\(\)" because "this.text" is null

### Improvement

[BL-328](https://ortussolutions.atlassian.net/browse/BL-328) Move CFID to compat module

[BL-612](https://ortussolutions.atlassian.net/browse/BL-612) Add STOMP subprotocols in miniserver

[BL-637](https://ortussolutions.atlassian.net/browse/BL-637) Have servlet runtime return actual pagecontext object instead of fake

[BL-644](https://ortussolutions.atlassian.net/browse/BL-644) Update the allowedFileOperationExtensions and disallowedFileOperationExtensions to the security block

[BL-650](https://ortussolutions.atlassian.net/browse/BL-650) Allow casting to array of primitive types

[BL-652](https://ortussolutions.atlassian.net/browse/BL-652) Improve exception when trying to invoke null as a function

[BL-654](https://ortussolutions.atlassian.net/browse/BL-654) Get ColdBox Loading via ASM

[BL-655](https://ortussolutions.atlassian.net/browse/BL-655) Improve logic surrounding loading of pre-compiled source files

[BL-660](https://ortussolutions.atlassian.net/browse/BL-660) added a \`isCommitted\(\)\` to the PageContext to match the servlet response to assist when doing resets without exceptions

[BL-661](https://ortussolutions.atlassian.net/browse/BL-661) StopGaps and config from cfconfig.json to boxlang.json

[BL-662](https://ortussolutions.atlassian.net/browse/BL-662) NotImplemented updated to check if it's a string and if empty, then ignore it to provide leeway

[BL-666](https://ortussolutions.atlassian.net/browse/BL-666) Rename default sessions cache to \`bxSessions\` to create the \`bx\` prefix standards. Add configuration to boxlang.json

### New Feature

[BL-232](https://ortussolutions.atlassian.net/browse/BL-232) Star-import for boxlang classes

[BL-646](https://ortussolutions.atlassian.net/browse/BL-646) Ability to import/create BoxLang classes from modules via direct \`@\{moduleName\}\` notation.

[BL-647](https://ortussolutions.atlassian.net/browse/BL-647) Ability to import create java classes from modules explicitly using the \`@\`notation

[BL-648](https://ortussolutions.atlassian.net/browse/BL-648) Import Definitions now support module addressing for simple, wildcard and aliases

[BL-653](https://ortussolutions.atlassian.net/browse/BL-653) Java wildcard imports from loaded jars

[BL-657](https://ortussolutions.atlassian.net/browse/BL-657) JavaResolver module targeted resolution

[BL-658](https://ortussolutions.atlassian.net/browse/BL-658) MIgrate AST Capture to it's own experimental flag

[BL-667](https://ortussolutions.atlassian.net/browse/BL-667) ASMBoxPiler to do direct java bytecode creation

[BL-635]: https://ortussolutions.atlassian.net/browse/BL-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-636]: https://ortussolutions.atlassian.net/browse/BL-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-639]: https://ortussolutions.atlassian.net/browse/BL-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-642]: https://ortussolutions.atlassian.net/browse/BL-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-645]: https://ortussolutions.atlassian.net/browse/BL-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-649]: https://ortussolutions.atlassian.net/browse/BL-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-651]: https://ortussolutions.atlassian.net/browse/BL-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-659]: https://ortussolutions.atlassian.net/browse/BL-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-328]: https://ortussolutions.atlassian.net/browse/BL-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ