### PR TITLE
1.0.0-Beta27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,22 +50,19 @@ dependencies {
 	// LOCAL DEVELOPMENT ONLY
 	// CHOOSE THE RIGHT LOCATION FOR YOUR LOCAL DEPENDENCIES
     implementation files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '-all.jar' )
-	implementation files( '../boxlang-web-support/build/distributions/boxlang-web-support-' + boxlangVersion + '.jar' )
 
 	// Downloaded Dependencies
 	implementation files( 'src/test/resources/libs/boxlang-web-support-' + boxlangVersion + '.jar' )
 	implementation files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )
 
 	// Servlet API
-	implementation 'javax.servlet:javax.servlet-api:4.0.1'
+	implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 	// We only need these for the PageContext class
-	implementation 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.3'
-	implementation 'javax.el:javax.el-api:3.0.0'
+	implementation 'jakarta.servlet.jsp:jakarta.servlet.jsp-api:4.0.0'
+	implementation 'jakarta.el:jakarta.el-api:5.0.0'
 
-
-
- 	implementation 'commons-fileupload:commons-fileupload:1.5'
-
+ 	implementation 'org.apache.commons:commons-fileupload2-jakarta-servlet5:2.0.0-M2'
+	
     // Testing Dependencies
     testImplementation "org.junit.jupiter:junit-jupiter:5.+"
 	testImplementation "org.mockito:mockito-core:5.+"

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta26] - 2025-01-17
+
 ## [1.0.0-beta25] - 2024-12-13
 
 ## [1.0.0-beta24] - 2024-12-02
@@ -61,7 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta25...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta26...HEAD
+
+[1.0.0-beta26]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta25...v1.0.0-beta26
 
 [1.0.0-beta25]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta24...v1.0.0-beta25
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta25] - 2024-12-13
+
 ## [1.0.0-beta24] - 2024-12-02
 
 ## [1.0.0-beta23] - 2024-11-23
@@ -59,7 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this runtime
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta24...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta25...HEAD
+
+[1.0.0-beta25]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta24...v1.0.0-beta25
 
 [1.0.0-beta24]: https://github.com/ortus-boxlang/boxlang-servlet/compare/v1.0.0-beta23...v1.0.0-beta24
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Dec 13 21:23:39 UTC 2024
-boxlangVersion=1.0.0-beta26
+#Fri Jan 17 16:15:11 UTC 2025
+boxlangVersion=1.0.0-beta27
 jdkVersion=21
-version=1.0.0-beta26
+version=1.0.0-beta27
 group=ortus.boxlang

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Mon Dec 02 11:44:52 UTC 2024
-boxlangVersion=1.0.0-beta25
+#Fri Dec 13 21:23:39 UTC 2024
+boxlangVersion=1.0.0-beta26
 jdkVersion=21
-version=1.0.0-beta25
+version=1.0.0-beta26
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxLangServlet.java
@@ -22,14 +22,13 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;

--- a/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
+++ b/src/main/java/ortus/boxlang/servlet/BoxPageContext.java
@@ -5,18 +5,16 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.el.ELContext;
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.jsp.JspWriter;
-import javax.servlet.jsp.PageContext;
-import javax.servlet.jsp.el.ExpressionEvaluator;
-import javax.servlet.jsp.el.VariableResolver;
+import jakarta.el.ELContext;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.jsp.JspWriter;
+import jakarta.servlet.jsp.PageContext;
 
 public class BoxPageContext extends PageContext {
 
@@ -230,18 +228,6 @@ public class BoxPageContext extends PageContext {
 			// out.flush();
 		}
 		request.getRequestDispatcher( path ).include( request, response );
-	}
-
-	@SuppressWarnings( "deprecation" )
-	@Override
-	public ExpressionEvaluator getExpressionEvaluator() {
-		throw new UnsupportedOperationException( "Not supported yet." );
-	}
-
-	@SuppressWarnings( "deprecation" )
-	@Override
-	public VariableResolver getVariableResolver() {
-		throw new UnsupportedOperationException( "Not supported yet." );
 	}
 
 	@Override

--- a/src/main/java/ortus/boxlang/servlet/ServletMappingInterceptor.java
+++ b/src/main/java/ortus/boxlang/servlet/ServletMappingInterceptor.java
@@ -19,8 +19,7 @@ package ortus.boxlang.servlet;
 
 import java.nio.file.Path;
 
-import javax.servlet.ServletContext;
-
+import jakarta.servlet.ServletContext;
 import ortus.boxlang.runtime.events.BaseInterceptor;
 import ortus.boxlang.runtime.events.InterceptionPoint;
 import ortus.boxlang.runtime.events.Interceptor;

--- a/src/main/java/ortus/boxlang/servlet/ServletMappingInterceptor.java
+++ b/src/main/java/ortus/boxlang/servlet/ServletMappingInterceptor.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletContext;
 
 import ortus.boxlang.runtime.events.BaseInterceptor;
 import ortus.boxlang.runtime.events.InterceptionPoint;
+import ortus.boxlang.runtime.events.Interceptor;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.util.ResolvedFilePath;
@@ -30,13 +31,19 @@ import ortus.boxlang.runtime.util.ResolvedFilePath;
 /**
  * I allow paths to be expanded using the servlets mappings/resource manager
  */
+@Interceptor( autoLoad = false )
 public class ServletMappingInterceptor extends BaseInterceptor {
 
 	private ServletContext servletContext;
 
 	/**
+	 * No Arg-Constructor
+	 */
+	public ServletMappingInterceptor() {
+	}
+
+	/**
 	 * Constructor
-	 *
 	 */
 	public ServletMappingInterceptor( ServletContext servletContext ) {
 		this.servletContext = servletContext;

--- a/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
@@ -14,8 +14,7 @@
  */
 package ortus.boxlang.web.bifs;
 
-import javax.servlet.jsp.JspWriter;
-
+import jakarta.servlet.jsp.JspWriter;
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;

--- a/src/main/resources/boxlang-servlet/box.json
+++ b/src/main/resources/boxlang-servlet/box.json
@@ -5,5 +5,6 @@
 	"type": "cf-engines",
 	"description": "The CommandBox Engine for BoxLang",
 	"createPackageDirectory": false,
-	"listed": true
+	"listed": true,
+	"JakartaEE": true
 }


### PR DESCRIPTION
This release brings enhanced XML handling, new CLI app support, improved error handling, and expanded interoperability with Java and CFML runtimes. We've also added new HTTP event hooks, improved caching strategies, and a streamlined class resolution process to make your applications more performant, even in debug modes.
🌟 Highlights:
✅ Enhanced XML Support – Improved cloning, merging, and namespace handling in XML operations.
✅ Unified Template & Script Grammars – BoxLang now seamlessly integrates both styles, bringing performance updates to the parser.
✅ Improved Java Interop – Automatic coercion of BoxLang arrays to native Java arrays and varargs support
✅ Better Error Handling – More robust dump rendering and exception management.
✅ New CLI Features – Built-in functions like cliRead(), cliGetArgs(), and cliExit() for pure CLI apps.
✅ Improved HTTP Handling – Proxy support, authentication, and new request/response events.
✅ Trusted Cache – Trusted cache is in the house, to get high performance in production
✅ Class location caches – More performance updates for class resolutions for BoxLang classes

With over 40 improvements, new features, and fixes, this release makes BoxLang even more powerful and stable! 🔥
Improvements
[BL-953](https://ortussolutions.atlassian.net/browse/BL-953) Implement Node pass-through methods to handle cloning and merging of XML objects
[BL-955](https://ortussolutions.atlassian.net/browse/BL-955) Combine template and script grammars for boxlang
[BL-956](https://ortussolutions.atlassian.net/browse/BL-956) Error Getting method keyExists for class ortus.boxlang.runtime.types.XML
[BL-958](https://ortussolutions.atlassian.net/browse/BL-958) StructFindKey returns two findings on the same node if top level key is array
[BL-959](https://ortussolutions.atlassian.net/browse/BL-959) Better error handling when dump template errors
[BL-964](https://ortussolutions.atlassian.net/browse/BL-964) Return callback return value from runThreadInContext()
[BL-966](https://ortussolutions.atlassian.net/browse/BL-966) java interop coerce BL arrays to native arrays
[BL-967](https://ortussolutions.atlassian.net/browse/BL-967) Add toOptional() method to Attempt
[BL-968](https://ortussolutions.atlassian.net/browse/BL-968) coerce return values of proxied methods
[BL-983](https://ortussolutions.atlassian.net/browse/BL-983) output class of non-simple valued fields in class output for cfdump
[BL-984](https://ortussolutions.atlassian.net/browse/BL-984) prefer same mapping for relative class lookups in box resolver
[BL-998](https://ortussolutions.atlassian.net/browse/BL-998) Client scope needs more consistencies like the session scope when validating and expiration determination
[BL-999](https://ortussolutions.atlassian.net/browse/BL-999) Module service record was not registering interceptors with the module settings
[BL-1002](https://ortussolutions.atlassian.net/browse/BL-1002) HTTP Component - Implement Proxy Server handling
[BL-1010](https://ortussolutions.atlassian.net/browse/BL-1010) add default itnerface helper for the IBoxContext to get the running application name if any
[BL-1013](https://ortussolutions.atlassian.net/browse/BL-1013) Servlet to support Jakarta namespace
New Features
[BL-843](https://ortussolutions.atlassian.net/browse/BL-843) Move defaultCache to the caches section as default, verify it exists, else create it anyways
[BL-935](https://ortussolutions.atlassian.net/browse/BL-935) add http events: onHTTPRequest, onHTTPResponse
[BL-952](https://ortussolutions.atlassian.net/browse/BL-952) Expose buildRegistry() and encapsulate per location registration
[BL-989](https://ortussolutions.atlassian.net/browse/BL-989) CLI BIFS for working with pure cli apps: cliRead(), cliGetArgs(), cliExit()
[BL-1009](https://ortussolutions.atlassian.net/browse/BL-1009) Activate box resolvers cache according to request and app settings
[BL-1016](https://ortussolutions.atlassian.net/browse/BL-1016) New setting: classResolverCache : boolean [true] which controls if the class locators caches resolve lookups
Bugs
[BL-389](https://ortussolutions.atlassian.net/browse/BL-389) varargs not working
[BL-931](https://ortussolutions.atlassian.net/browse/BL-931) CF casts Class instances to a String
[BL-947](https://ortussolutions.atlassian.net/browse/BL-947) Namespaced XML nodes not accessible by their non-namespaced names
[BL-949](https://ortussolutions.atlassian.net/browse/BL-949) XMLSearch Not Finding Correct Results When Namespaces are Present
[BL-950](https://ortussolutions.atlassian.net/browse/BL-950) XML asString Generates trailing line break
[BL-951](https://ortussolutions.atlassian.net/browse/BL-951) StructFindKey Not Returning owner values correctly
[BL-960](https://ortussolutions.atlassian.net/browse/BL-960) ASM compilation error
[BL-961](https://ortussolutions.atlassian.net/browse/BL-961) query with empty column name can't be dumped
[BL-965](https://ortussolutions.atlassian.net/browse/BL-965) WriteDump()/Dump() is broken in current snapshot build
[BL-969](https://ortussolutions.atlassian.net/browse/BL-969) DateCompare on two zero-hour strings fails with long overflow
[BL-970](https://ortussolutions.atlassian.net/browse/BL-970) XMLElemNew Illegal Character exception when using the namespace URI as the second argument
[BL-977](https://ortussolutions.atlassian.net/browse/BL-977) HTTP Component - Implement Basic Authentication
[BL-978](https://ortussolutions.atlassian.net/browse/BL-978) Cannot access variables scope in a static context -- but there is no variables access
[BL-981](https://ortussolutions.atlassian.net/browse/BL-981) timezone not always used in datetime caster
[BL-982](https://ortussolutions.atlassian.net/browse/BL-982) toUnmodifiableStruct() method not threadsafe
[BL-985](https://ortussolutions.atlassian.net/browse/BL-985) directoryList filter param does not accept a closure
[BL-991](https://ortussolutions.atlassian.net/browse/BL-991) Support for guid and uuid type
[BL-994](https://ortussolutions.atlassian.net/browse/BL-994) getDirectoryFromPath returns different result to Lucee and ACF
[BL-995](https://ortussolutions.atlassian.net/browse/BL-995) argument type of binary is not supported
[BL-996](https://ortussolutions.atlassian.net/browse/BL-996) argument type of email is not supported
[BL-1000](https://ortussolutions.atlassian.net/browse/BL-1000) CGI scope reporting 0 items
[BL-1003](https://ortussolutions.atlassian.net/browse/BL-1003) JSONSerialize pretty prints JSON which blows up outbound NDJSON
[BL-1004](https://ortussolutions.atlassian.net/browse/BL-1004) CFHTTParam Encodes Query Strings By Default
[BL-1005](https://ortussolutions.atlassian.net/browse/BL-1005) URLEncodedFormat Replaces Spaces with Plus Symbols
[BL-1015](https://ortussolutions.atlassian.net/browse/BL-1015) Bracket Notation Usage on Java Hashmaps Does not work.
[BL-1017](https://ortussolutions.atlassian.net/browse/BL-1017) Detail and Extended Info Can Be Null In Thrown Exceptions

[BL-953]: https://ortussolutions.atlassian.net/browse/BL-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ